### PR TITLE
Allow overriding the underlying map type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 
 	for (ecs::Entity e : entityManager.EntitiesWith<Position>())
 	{
-		ecs::Handle<Position> position = e.Get<Position>();
+		auto position = e.Get<Position>(); // returns an ecs::Handle<Position>
 		std::cout << e
 		          << " has x: " << position->x
 		          << ", y: " << position-y
@@ -63,3 +63,18 @@ Output:
 Existing tests can be run on linux with "make tests" to run integration and unit tests or "make integration-tests" / "make unit-tests" to run the individual suites.
 
 googletest library is used to help with testing and it will automatically be cloned from github into the ```ext/``` directory when compiling the tests for the first time.
+
+# Performance
+
+By default, Glomerate uses std::unordered_map for storing indexes. On some
+platforms (in particular VC++), std::unordered_map performs poorly and should
+be replaced. This can be done by defining the GLOMERATE_MAP_TYPE macro before
+including any Glomerate header. For instance:
+
+```c++
+#include <boost/unordered_map.hpp>
+#define GLOMERATE_MAP_TYPE boost::unordered_map
+#include <Ecs.hh>
+```
+
+Any type with a similar interface can be used.

--- a/include/ecs/Common.hh
+++ b/include/ecs/Common.hh
@@ -25,6 +25,11 @@ typedef int32_t int32;
 typedef uint64_t uint64;
 typedef int64_t int64;
 
+#ifndef GLOMERATE_MAP_TYPE
+#include <unordered_map>
+#define GLOMERATE_MAP_TYPE std::unordered_map
+#endif
+
 namespace ecs
 {
 	void Assert(bool condition);

--- a/include/ecs/ComponentManager.hh
+++ b/include/ecs/ComponentManager.hh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <typeindex>
-#include <unordered_map>
 #include <bitset>
 #include <sstream>
 
@@ -77,7 +76,7 @@ namespace ecs
 		// map the typeid(T) of a component type, T, to the "index" of that
 		// component type. Any time each component type stores info in a vector, this index
 		// will identify which component type it corresponds to
-		std::unordered_map<std::type_index, uint32> compTypeToCompIndex;
+		GLOMERATE_MAP_TYPE<std::type_index, uint32> compTypeToCompIndex;
 
 		// An entity's index gives a bitmask for the components that it has. If bitset[i] is set
 		// then it means this entity has the component with component index i

--- a/include/ecs/ComponentStorage.hh
+++ b/include/ecs/ComponentStorage.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <unordered_map>
 #include <bitset>
 #include <queue>
 #include <iterator>
@@ -119,7 +118,7 @@ namespace ecs
 
 		vector<std::pair<Entity::Id, CompType> > components;
 		uint64 lastCompIndex;
-		std::unordered_map<uint64, uint64> entIndexToCompIndex;
+		GLOMERATE_MAP_TYPE<uint64, uint64> entIndexToCompIndex;
 		bool softRemoveMode;
 		std::queue<uint64> softRemoveCompIndexes;
 


### PR DESCRIPTION
VC++ debug-mode `std::unordered_map` is unusably slow and needs to be replaced. `boost::unordered_map` and many other containers share the same API as `std::unordered_map` so they can simply be dropped in.

The correct C++ way to do this is probably with templates, but I think this is much simpler.
