### PR TITLE
Add ToString for Entity and Entity::Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,23 @@ int main(int argc, char **argv)
 Output:
 
 ```c++
-(Index: 1, Gen: 0) has x: 1, y: 2,  z: 3
+1@0 has x: 1, y: 2,  z: 3
 ```
+
+# Entity IDs
+
+An `Entity::Id` is an opaque 64-bit integer that uniquely represents an entity.
+It may be passed by value or cached and will remain usable until the entity is
+destroyed.
+
+Applications usually treat `Entity::Id` as an indivisible type, however it is
+useful to understand the implementation details. IDs are composed of an *index*
+and *generation*. When an entity is destroyed, the index is returned to the
+pool of available indexes, and the generation for that index is incremented.
+To check if an entity is destroyed, use `Entity::Valid()`, which compares the
+entity's generation with the current generation for its index.
+
+The string representation of an Entity is in the format `index@generation`.
 
 # Events
 

--- a/include/ecs/Entity.hh
+++ b/include/ecs/Entity.hh
@@ -35,8 +35,8 @@ namespace ecs
 			Id &operator=(const Id &) & = default;
 
 			uint64 Index() const;
-
 			uint64 Generation() const;
+			string ToString() const;
 
 			bool operator==(const Id &other) const;
 			bool operator!=(const Id &other) const;
@@ -78,6 +78,11 @@ namespace ecs
 		 * (should not matter to API users)
 		 */
 		uint16 Generation() const;
+
+		/**
+		 * Retrieve a unique string representation of this Entity
+		 */
+		string ToString() const;
 
 		/**
 		 * Remove the given entity from the ECS.

--- a/include/ecs/EntityImpl.hh
+++ b/include/ecs/EntityImpl.hh
@@ -39,7 +39,7 @@ namespace ecs
 
 	inline std::ostream &operator<<(std::ostream &os, const Entity::Id e)
 	{
-		os << "(Index: " << e.Index() << ", Gen: " << e.Generation() << ")";
+		os << e.ToString();
 		return os;
 	}
 

--- a/include/ecs/EntityImpl.hh
+++ b/include/ecs/EntityImpl.hh
@@ -17,6 +17,11 @@ namespace ecs
 		return (id >> INDEX_BITS);
 	}
 
+	inline string Entity::Id::ToString() const
+	{
+		return std::to_string(Index()) + "@" + std::to_string(Generation());
+	}
+
 	inline bool Entity::Id::operator==(const Id &other) const
 	{
 		return id == other.id;
@@ -83,6 +88,11 @@ namespace ecs
 	inline uint16 Entity::Generation() const
 	{
 		return eid.Generation();
+	}
+
+	inline string Entity::ToString() const
+	{
+		return eid.ToString();
 	}
 
 	template <typename CompType, typename ...T>


### PR DESCRIPTION
I'd like to have a short string representation for debug output. Should the stream operator maybe use this? Or just keep both?